### PR TITLE
Main loop: Updated

### DIFF
--- a/inc/FuncUnit.hpp
+++ b/inc/FuncUnit.hpp
@@ -1,3 +1,0 @@
-#include "Instruction.hpp"
-
-class

--- a/inc/FuncUnit.hpp
+++ b/inc/FuncUnit.hpp
@@ -1,0 +1,3 @@
+#include "Instruction.hpp"
+
+class

--- a/inc/FunctionalUnit.hpp
+++ b/inc/FunctionalUnit.hpp
@@ -3,4 +3,4 @@
 
 class FunctionalUnit {
   virtual void processInstruction(Instruction& I, MachineState& MS) = 0;
-}
+};

--- a/inc/MachineState.hpp
+++ b/inc/MachineState.hpp
@@ -15,4 +15,10 @@ public:
   bool running;
 
   MachineState(uint64_t starting_addr);
+
+  int updateState(int &state)
+  {
+    state = state + 1;
+    return state;
+  }
 };

--- a/inc/MachineState.hpp
+++ b/inc/MachineState.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Register.hpp"
+#include <cstdint>
+#include <vector>
+#include <map>
+
+class MachineState
+{
+public:
+  std::vector<Register> registerFile;
+  std::map<uint64_t, Register> memory;
+
+  uint32_t pc;
+  bool running;
+
+  MachineState(uint64_t starting_addr);
+};

--- a/inc/MachineState.hpp
+++ b/inc/MachineState.hpp
@@ -15,10 +15,4 @@ public:
   bool running;
 
   MachineState(uint64_t starting_addr);
-
-  int updateState(int &state)
-  {
-    state = state + 1;
-    return state;
-  }
 };

--- a/inc/Register.hpp
+++ b/inc/Register.hpp
@@ -1,0 +1,30 @@
+class Register
+{
+    uint32_t num_elements;
+    uint32_t *raw_ints;
+
+public:
+    Register(int bitsize);
+    Register(const Register &);
+    Register &operator=(const Register &);
+    ~Register();
+
+    Register operator+(const int32_t);
+    Register operator+(const Register &);
+    Register operator-(const int32_t);
+    Register operator-(const Register &);
+    Register operator<<(const int32_t);
+    Register operator<<(const Register &);
+    Register operator^(const int32_t);
+    Register operator^(const Register &);
+    Register operator|(const int32_t);
+    Register operator|(const Register &);
+    Register operator&(const int32_t);
+    Register operator&(const Register &);
+
+    bool operator<(const Register &);
+    bool operator<(const int32_t);
+    bool operator>=(const Register &);
+
+    bool unsigned_lt(const int32_t);
+};

--- a/inc/Register.hpp
+++ b/inc/Register.hpp
@@ -1,30 +1,35 @@
-class Register
-{
-    uint32_t num_elements;
-    uint32_t *raw_ints;
+#pragma once
 
-public:
-    Register(int bitsize);
-    Register(const Register &);
-    Register &operator=(const Register &);
-    ~Register();
+#include <cstdint>
+#include <boost/multiprecision/cpp_int.hpp>
 
-    Register operator+(const int32_t);
-    Register operator+(const Register &);
-    Register operator-(const int32_t);
-    Register operator-(const Register &);
-    Register operator<<(const int32_t);
-    Register operator<<(const Register &);
-    Register operator^(const int32_t);
-    Register operator^(const Register &);
-    Register operator|(const int32_t);
-    Register operator|(const Register &);
-    Register operator&(const int32_t);
-    Register operator&(const Register &);
+using Register = boost::multiprecision::cpp_int;
 
-    bool operator<(const Register &);
-    bool operator<(const int32_t);
-    bool operator>=(const Register &);
+// class Register {
+//   uint32_t  num_elements;
+//   uint32_t* raw_ints;
+// public:
+//   Register(int bitsize);
+//   Register(const Register&);
+//   Register& operator=(const Register&);
+//   ~Register();
 
-    bool unsigned_lt(const int32_t);
-};
+//   Register operator+(const int32_t);
+//   Register operator+(const Register&);
+//   Register operator-(const int32_t);
+//   Regsiter operator-(const Register&);
+//   Register operator<<(const int32_t);
+//   Register operator<<(const Register&);
+//   Register operator^(const int32_t);
+//   Register operator^(const Register&);
+//   Register operator|(const int32_t);
+//   Register operator|(const Register&);
+//   Register operator&(const int32_t);
+//   Register operator&(const Register&);
+
+//   bool operator<(const Register&);
+//   bool operator<(const int32_t);
+//   bool operator>=(const Register&);
+
+//   bool unsigned_lt(const int32_t);
+// };

--- a/inc/consts.hpp
+++ b/inc/consts.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#define INSTRS_PER_PACKET 7
+#define INSTR_SIZE 4
+#define PACKET_SIZE INSTRS_PER_PACKET *INSTR_SIZE
+#define NUM_REGISTERS 32

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,0 @@
-file(GLOB all_SRCS
-        "${PrimSim_SOURCE_DIR}/src/*.cpp"
-        )
-include_directories(${PrimSim_SOURCE_DIR}/inc)
-include_directories(${Boost_INCLUDE_DIRS})
-add_executable(VLIWParsing ${all_SRCS})
-target_link_libraries(VLIWParsing ${Boost_LIBRARIES})

--- a/src/Instruction.cpp
+++ b/src/Instruction.cpp
@@ -26,7 +26,7 @@ private:
     int immediate;
     string assembly;
     type inst;
-
+public:
     Instruction(int raw_instruction)
     {
         this->raw_instruction = raw_instruction;

--- a/src/MachineState.cpp
+++ b/src/MachineState.cpp
@@ -1,7 +1,7 @@
 #include "MachineState.hpp"
 #include "consts.hpp"
 
-MachineState::MachineState(uint64_t starting_addr) : registerFile(NUM_REGISTERS, 0),
+MachineState::MachineState(uint64_t starting_addr) : registerFile(NUM_REGISTERS, 0), //num registers is the only const used?
                                                      memory(),
                                                      pc(starting_addr),
                                                      running(true)

--- a/src/MachineState.cpp
+++ b/src/MachineState.cpp
@@ -1,0 +1,9 @@
+#include "MachineState.hpp"
+#include "consts.hpp"
+
+MachineState::MachineState(uint64_t starting_addr) : registerFile(NUM_REGISTERS, 0),
+                                                     memory(),
+                                                     pc(starting_addr),
+                                                     running(true)
+{
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ void get_data(Instruction dat)
 
 int main(int argc, char *argv[])
 {
-    /*Pseudo code to be implemented as suggested by Kayvan and interpreted by me
+    /*Pseudo code to be implemented as suggested by Kayvan
     // error if not enough arguments
     // error if too many arguments
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,11 +7,13 @@
 #include "MachineState.cpp"
 #include "Instruction.cpp"
 #include "FunctionalUnit.hpp"
+#include <alu.hpp>
 using namespace std;
 
-int total_instructions = 14;
+int instruction_width = 0;
 int num_BFU = 0;
 int num_merged = 0;
+int num_branch = 1;
 
 void readNumUnits(string filename)
 {
@@ -32,10 +34,15 @@ void readNumUnits(string filename)
             string word1 = word.substr(0, 9);
             if (word1.compare("NUM_ALUS=") == 0)
             {
-                continue;
+                num_merged = stoi(word.substr(10), 0, 10);
+            }
+            if (word1.compare("NUM_BFUS=") == 0)
+            {
+                num_BFU = stoi(word.substr(10), 0, 10) - 1; // -1 for the branch. I don't know what to do about the branch unit yet
             }
         }
     }
+    instruction_width = num_merged + num_BFU + num_branch;
 }
 // stringToBinary function is used since issues with stoi staying in 32 bits
 int stringToBinary(string test)
@@ -121,7 +128,7 @@ vector<vector<Instruction>> read(const string &filename)
 
     while (getline(inputFile, line))
     {
-        if (CurPacket.size() >= total_instructions)
+        if (CurPacket.size() >= instruction_width)
         {
             VLIW.push_back(CurPacket);
             CurPacket.clear();
@@ -142,7 +149,7 @@ vector<vector<Instruction>> read(const string &filename)
     if (!CurPacket.empty())
     {
         // Only push CurPacket if it contains exactly total_instructions instructions
-        if (CurPacket.size() == total_instructions)
+        if (CurPacket.size() == instruction_width)
         {
             VLIW.push_back(CurPacket);
         }
@@ -182,14 +189,28 @@ int main(int argc, char *argv[])
     string filePath_instruction = argv[1];
     string filePath_config = argv[2];
 
+    vector<shared_ptr<FunctionalUnit>> allUnits; // IDK why this works, but stack overflow says it does
+    // This has to happen first because the instruction width is calculated in this function
+    while (num_branch != 0)
+    {
+        allUnits.push_back(make_shared<BranchUnit>());
+        num_branch--;
+    }
+    while (num_BFU != 0)
+    {
+        allUnits.push_back(make_shared<BFU>());
+        num_BFU--;
+    }
+    while (num_merged != 0)
+    {
+        allUnits.push_back(make_shared<ALU>()); // This needs to change in order to accomodate between green and blue functional unit once wrapper class is written
+        num_merged--;
+    }
+
     // reading an parsing done here (bug will appear since "consts.hpp" has different dimensions for VLIW than my hardcoded main)
     vector<vector<Instruction>> instructions = read(filePath_instruction);
 
-    vector<shared_ptr<FunctionalUnit>> allUnits; // IDK why this works, but stack overflow says it does
-
-    MachineState Machine0(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
-
-    // Initialize Functional Units over here
+    MachineState Machine0(0); // initial machine state (the initial PC might be a bug)
 
     // Throw warnings if same destination
     // If statement necessary in order to make sure that I don't get an out of range exception from the nested for loopss
@@ -210,8 +231,10 @@ int main(int argc, char *argv[])
 
     while (Machine0.running)
     {
-
-        processInstruction(instructions, Machine0);
+        for (const auto &unit : allUnits)
+        {
+            unit->processInstruction(instructions.at(Machine0.pc), Machine0);
+        }
     }
 
     cout << "Hello, World!" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,8 +106,8 @@ vector<vector<Instruction>> read(const string &filename)
 
         while (iss >> word)
         {
-            uint32_t unum = (uint32_t)(stoul(word, nullptr, 16));
-            int num = static_cast<int>(unum);
+
+            int num = stringToBinary(word);
             Instruction CurInstruct(num);
             CurPacket.push_back(CurInstruct);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <sstream>
 #include <string>
 #include "Instruction.cpp"
+#include <cstdint>
+#include "MachineState.cpp"
 
 using namespace std;
 
@@ -36,7 +38,9 @@ vector<vector<Instruction>> read(const string &filename)
 
         while (iss >> word)
         {
-            Instruction CurInstruct(stoi(word, 0, 16));
+            uint32_t unum = (uint32_t)(stoul(word, nullptr, 16));
+            int num = static_cast<int>(unum);
+            Instruction CurInstruct(num);
             CurPacket.push_back(CurInstruct);
         }
     }
@@ -72,14 +76,74 @@ void get_data(Instruction dat)
 
 int main(int argc, char *argv[])
 {
-    if (argc != 2)
+    /*Pseudo code to be implemented as suggested by Kayvan and interpreted by me
+    // error if not enough arguments
+    // error if too many arguments
+
+    // read in the file
+
+    // parse the file
+
+    // create initial machine state (Machine state new class)
+
+    // create Backend instance (vector<FunctionalUnit>)
+
+    // loop program until finished
+    while(!halted) {
+
+
+        // fetch - already done by parsing the file
+
+
+        // decode - part of the execute since instruction will go to functional unit
+
+
+        // execute - function proc(instruction) will be run, method written by someone else, can be modified to run each instruction of a vector or one VLIW
+        !!!!!!! Throw a warning if the destination registers of a VLIW are the same to help debug the compiler LLVM stuff in the future
+        !!!!!!! An error might occur from consts.hpp
+
+        // writeback - TBD who updates the machine state
+    }
+
+    // print final machine state (eventually)
+    */
+
+    if (argc != 2) // error if wrong amount of arguments arguments
     {
         cerr << "Usage: " << argv[0] << " <file_path>" << endl;
         return 1;
     }
 
+    // current bug with stoi that doesn't work with the TCP file
+
     string filePath = argv[1];
-    vector<vector<Instruction>> instructions = read(filePath);
+    vector<vector<Instruction>> instructions = read(filePath); // reading an parsing done here
+
+    MachineState test = MachineState(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
+
+    // Throw warnings if same destination
+    for (int i = 0; i < instructions.size(); i++)
+    {
+        for (int j = 0; i < instructions.at(i).size() - 1; j++)
+        {
+            for (int k = 1; k < instructions.at(i).size(); k++)
+                if (instructions.at(i).at(j).get_rd() == instructions.at(i).at(k).get_rd())
+                {
+                    cout << j << " and " << k << " have the same destination register in Instruction " << i << endl;
+                }
+        }
+    }
+
+    while (test.running)
+    {
+        for (int i = 0; i < INSTRS_PER_PACKET; i++)
+        {
+            proc_instruction(instructions.at(i));
+        }
+    }
+
+    /*
+    // starting here 1.0, this creates an output file that I needed in order to test that I was parsing the instructions properly
 
     ofstream outfile("text.txt");
     if (!outfile.is_open())
@@ -94,13 +158,16 @@ int main(int argc, char *argv[])
         int j = 0; // Reset j for each new outer loop iteration
         while (j < instructions.at(i).size())
         {
-            outfile << instructions.at(i).at(j).get_instruction() << endl;
+            outfile << instructions.at(i).at(j).get_instruction() << " ";
             j++;
         }
+        outfile << endl;
         i++;
     }
 
     outfile.close();
+    // ending here 1.0
+    */
 
     cout << "Hello, World!" << endl;
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,37 +144,6 @@ void get_data(Instruction dat)
 
 int main(int argc, char *argv[])
 {
-    /*Pseudo code to be implemented as suggested by Kayvan
-    // error if not enough arguments
-    // error if too many arguments
-
-    // read in the file
-
-    // parse the file
-
-    // create initial machine state (Machine state new class)
-
-    // create Backend instance (vector<FunctionalUnit>)
-
-    // loop program until finished
-    while(!halted) {
-
-
-        // fetch - already done by parsing the file
-
-
-        // decode - part of the execute since instruction will go to functional unit
-
-
-        // execute - function proc(instruction) will be run, method written by someone else, can be modified to run each instruction of a vector or one VLIW
-        !!!!!!! Throw a warning if the destination registers of a VLIW are the same to help debug the compiler LLVM stuff in the future
-        !!!!!!! An error might occur from consts.hpp : The # of instructions comes from compiler but it's hard coded in .hpp
-
-        // writeback - TBD who updates the machine state
-    }
-
-    // print final machine state (eventually)
-    */
 
     if (argc != 2) // error if wrong amount of arguments arguments
     {
@@ -185,54 +154,35 @@ int main(int argc, char *argv[])
     // current bug with stoi that doesn't work with the TCP file
 
     string filePath = argv[1];
-    vector<vector<Instruction>> instructions = read(filePath); // reading an parsing done here
 
-    MachineState test(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
+    // reading an parsing done here (bug will appear since "consts.hpp" has different dimensions for VLIW than my hardcoded main)
+    vector<vector<Instruction>> instructions = read(filePath);
+
+    MachineState Machine0(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
+
+    // Initialize Functional Units over here
 
     // Throw warnings if same destination
-    for (int i = 0; i < instructions.size(); i++)
+    // If statement necessary in order to make sure that I don't get an out of range exception from the nested for loops
+    if (instrcution.size() >= 2)
     {
-        for (int j = 0; i < instructions.at(i).size() - 1; j++)
+        for (auto i : instructions)
         {
-            for (int k = 1; k < instructions.at(i).size(); k++)
-                if (instructions.at(i).at(j).get_rd() == instructions.at(i).at(k).get_rd())
-                {
-                    cout << j << " and " << k << " have the same destination register in Instruction " << i << endl;
-                }
+            for (int j = 0; i < instructions.at(i).size() - 1; j++)
+            {
+                for (int k = j + 1; k < instructions.at(i).size(); k++)
+                    if (instructions.at(i).at(j).get_rd() == instructions.at(i).at(k).get_rd())
+                    {
+                        cout << j << " and " << k << " have the same destination register in Instruction " << i << endl;
+                    }
+            }
         }
     }
 
-    while (test.running)
+    while (Machine0.running)
     {
-        proc_instruction(instructions, test);
+        proc_instruction(instructions, Machine0);
     }
-
-    /*
-    // starting here 1.0, this creates an output file that I needed in order to test that I was parsing the instructions properly
-
-    ofstream outfile("text.txt");
-    if (!outfile.is_open())
-    {
-        cerr << "Error: Could not open the file 'text.txt' for writing." << endl;
-        return 1;
-    }
-
-    int i = 0;
-    while (i < instructions.size())
-    {
-        int j = 0; // Reset j for each new outer loop iteration
-        while (j < instructions.at(i).size())
-        {
-            outfile << instructions.at(i).at(j).get_instruction() << " ";
-            j++;
-        }
-        outfile << endl;
-        i++;
-    }
-
-    outfile.close();
-    // ending here 1.0
-    */
 
     cout << "Hello, World!" << endl;
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,14 +3,40 @@
 #include <vector>
 #include <sstream>
 #include <string>
-#include "Instruction.cpp"
 #include <cstdint>
 #include "MachineState.cpp"
-
+#include "Instruction.cpp"
+#include "FunctionalUnit.hpp"
 using namespace std;
 
 int total_instructions = 14;
+int num_BFU = 0;
+int num_merged = 0;
 
+void readNumUnits(string filename)
+{
+    ifstream inputFile(filename);
+    string line;
+
+    if (!inputFile.is_open())
+    {
+        cerr << "Error opening file" << endl;
+        return;
+    }
+    while (getline(inputFile, line))
+    {
+        istringstream iss(line);
+        string word;
+        while (iss >> word)
+        {
+            string word1 = word.substr(0, 9);
+            if (word1.compare("NUM_ALUS=") == 0)
+            {
+                continue;
+            }
+        }
+    }
+}
 // stringToBinary function is used since issues with stoi staying in 32 bits
 int stringToBinary(string test)
 {
@@ -145,7 +171,7 @@ void get_data(Instruction dat)
 int main(int argc, char *argv[])
 {
 
-    if (argc != 2) // error if wrong amount of arguments arguments
+    if (argc != 3) // error if wrong amount of arguments arguments
     {
         cerr << "Usage: " << argv[0] << " <file_path>" << endl;
         return 1;
@@ -153,20 +179,23 @@ int main(int argc, char *argv[])
 
     // current bug with stoi that doesn't work with the TCP file
 
-    string filePath = argv[1];
+    string filePath_instruction = argv[1];
+    string filePath_config = argv[2];
 
     // reading an parsing done here (bug will appear since "consts.hpp" has different dimensions for VLIW than my hardcoded main)
-    vector<vector<Instruction>> instructions = read(filePath);
+    vector<vector<Instruction>> instructions = read(filePath_instruction);
+
+    vector<shared_ptr<FunctionalUnit>> allUnits; // IDK why this works, but stack overflow says it does
 
     MachineState Machine0(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
 
     // Initialize Functional Units over here
 
     // Throw warnings if same destination
-    // If statement necessary in order to make sure that I don't get an out of range exception from the nested for loops
-    if (instrcution.size() >= 2)
+    // If statement necessary in order to make sure that I don't get an out of range exception from the nested for loopss
+    if (instructions.size() >= 2)
     {
-        for (auto i : instructions)
+        for (int i = 0; i < instructions.size(); i++)
         {
             for (int j = 0; i < instructions.at(i).size() - 1; j++)
             {
@@ -181,7 +210,8 @@ int main(int argc, char *argv[])
 
     while (Machine0.running)
     {
-        proc_instruction(instructions, Machine0);
+
+        processInstruction(instructions, Machine0);
     }
 
     cout << "Hello, World!" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,74 @@ using namespace std;
 
 int total_instructions = 14;
 
+// stringToBinary function is used since issues with stoi staying in 32 bits
+int stringToBinary(string test)
+{
+    int result = 0;
+    for (int i = 0; i < 8; i++)
+    {
+        result = result << 4;
+        switch (test[i])
+        {
+
+        case '0':
+            result += 0b0000;
+            break;
+        case '1':
+            result += 0b0001;
+            break;
+        case '2':
+            result += 0b0010;
+            break;
+        case '3':
+            result += 0b0011;
+            break;
+        case '4':
+            result += 0b0100;
+            break;
+        case '5':
+            result += 0b0101;
+            break;
+        case '6':
+            result += 0b0110;
+            break;
+        case '7':
+            result += 0b0111;
+            break;
+        case '8':
+            result += 0b1000;
+            break;
+        case '9':
+            result += 0b1001;
+            break;
+        case 'a':
+        case 'A':
+            result += 0b1010;
+            break;
+        case 'b':
+        case 'B':
+            result += 0b1011;
+            break;
+        case 'c':
+        case 'C':
+            result += 0b1100;
+            break;
+        case 'd':
+        case 'D':
+            result += 0b1101;
+            break;
+        case 'e':
+        case 'E':
+            result += 0b1110;
+            break;
+        default:
+            result += 0b1111;
+            break;
+        }
+    }
+    return result;
+}
+
 vector<vector<Instruction>> read(const string &filename)
 {
     vector<vector<Instruction>> VLIW;
@@ -100,7 +168,7 @@ int main(int argc, char *argv[])
 
         // execute - function proc(instruction) will be run, method written by someone else, can be modified to run each instruction of a vector or one VLIW
         !!!!!!! Throw a warning if the destination registers of a VLIW are the same to help debug the compiler LLVM stuff in the future
-        !!!!!!! An error might occur from consts.hpp
+        !!!!!!! An error might occur from consts.hpp : The # of instructions comes from compiler but it's hard coded in .hpp
 
         // writeback - TBD who updates the machine state
     }
@@ -119,7 +187,7 @@ int main(int argc, char *argv[])
     string filePath = argv[1];
     vector<vector<Instruction>> instructions = read(filePath); // reading an parsing done here
 
-    MachineState test = MachineState(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
+    MachineState test(0); // initial machine state (!!!!!!!!!!!! This will be a bug that needs to be changed)
 
     // Throw warnings if same destination
     for (int i = 0; i < instructions.size(); i++)
@@ -136,10 +204,7 @@ int main(int argc, char *argv[])
 
     while (test.running)
     {
-        for (int i = 0; i < INSTRS_PER_PACKET; i++)
-        {
-            proc_instruction(instructions.at(i));
-        }
+        proc_instruction(instructions, test);
     }
 
     /*


### PR DESCRIPTION
The simulator now takes in two files as command line arguments. The first is the assembly file. The second file is the .cfg file which specifies the number of green and blue functional units. This simulator still will not run since the vector of functional units is improperly declared. There are some functional units labeled as merged which is due to the fact that they could be either green or blue and is dependent on the instructions given. The solution to this problem is a wrapper class in order to determine whether to pass the instruction to a green or blue functional unit. This wrapper class will be written after both, green and blue, functional units are completed.